### PR TITLE
Swap bytes when building IPv6 addresses.

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -107,3 +107,13 @@ extern "C" {
     #[cfg(target_os = "macos")]
     pub fn rust_LLADDR(p: *mut ifaddrs) -> *const u8;
 }
+
+#[cfg(test)]
+mod tests {
+    use super::make_int16;
+
+    #[test]
+    fn test_make_int16() {
+        assert_eq!(make_int16(0xff, 0x00), 0xff00);
+    }
+}

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -57,7 +57,7 @@ extern "C" {
     pub fn freeifaddrs(ifa: *mut ifaddrs) -> c_void;
 }
 
-fn make_int16(lo: u8, hi: u8) -> u16 {
+fn make_int16(hi: u8, lo: u8) -> u16 {
     (lo as u16) | ((hi as u16) << 8)
 }
 


### PR DESCRIPTION
As an example, the IPv6 address fe80::1 is represented in memory (in a
sin6_addr.s6_addr) as:

[0xfe, 0x80, 0x00, ..., 0x01]

So to construct an IPv6 address from 16-bit values, as is required by
net::Ipv6Addr::new, these should be passed as 0xfe80, 0x0000, etc.
However, the make_int16() function here was building them as 0x80fe,
etc. (or rather, it was being *called* in such a way to construct such
swapped integers). Because this function is used only to build IPv6
addresses, simply swapping the order of its parameters is sufficient to
properly construct IPv6 addresses.