### PR TITLE
Bump minimum version of Rust to 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ rust:
   - stable
 
   # Minimum version of Rust supported
-  - 1.7.0
+  - 1.9.0
 
 before_script:
   - |


### PR DESCRIPTION
Builds were failing with a TOML parse error; let's move to a version of Rust that fixes this.