### PR TITLE
Add support for Raspberry Pi (and keep musl support previously added)

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -8,10 +8,10 @@ use std::ptr;
 #[cfg(not(target_pointer_width = "32"))]
 pub type ConstantType = u64;
  
-#[cfg(all(target_pointer_width  = "32",target_env = "musl"))]
+#[cfg(all(target_pointer_width = "32",target_env = "musl"))]
 pub type ConstantType = i32;
  
-#[cfg(all(target_pointer_width  = "32", not(target_env = "musl")))]
+#[cfg(all(target_pointer_width = "32", not(target_env = "musl")))]
 pub type ConstantType = u32;
 
 /// The constant as sent by the C side.

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -8,7 +8,7 @@ use std::ptr;
 #[cfg(not(target_pointer_width = "32"))]
 pub type ConstantType = u64;
  
-#[cfg(all(target_pointer_width = "32",target_env = "musl"))]
+#[cfg(all(target_pointer_width = "32", target_env = "musl"))]
 pub type ConstantType = i32;
  
 #[cfg(all(target_pointer_width = "32", not(target_env = "musl")))]

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -5,11 +5,14 @@ use std::mem;
 use std::os::raw::c_char;
 use std::ptr;
 
-#[cfg(not(target_env = "musl"))]
+#[cfg(not(target_pointer_width = "32"))]
 pub type ConstantType = u64;
-
-#[cfg(target_env = "musl")]
+ 
+#[cfg(all(target_pointer_width  = "32",target_env = "musl"))]
 pub type ConstantType = i32;
+ 
+#[cfg(all(target_pointer_width  = "32", not(target_env = "musl")))]
+pub type ConstantType = u32;
 
 /// The constant as sent by the C side.
 #[repr(C)]


### PR DESCRIPTION
Hello Andrew,

I have done the following patch for the issue #10.
Detection of 32/64 bits architecture is based on the target_pointer_width.
I have done the following assumption :
- musl is always signed
- other target_env are always unsigned

It should be better that the previous code, but I can't test every configurations.
I have tested on :
- Raspberry pi 1 (raspbian and archlinux arm 32bits).
- my linux PC (Debian SID 64 bits)

Here my simple test program : 
```rust
extern crate interfaces;

use interfaces::Interface;

fn main() {
    let interface = Interface::get_by_name("eth0").unwrap();
    if let Some(ref iface) = interface {
        match iface.hardware_addr() {
            Ok(hwaddr) => println!("HW address : {}", hwaddr.as_string()),
            Err(_) => println!("No HW address!")
	}
    } else {
        println!("Could not find eth0 interface");
    }
}
```