### PR TITLE
Switch from gcc to cc crate for C compilation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ libc = "0.2"
 nix = "0.9"
 
 [build-dependencies]
-gcc = "0.3"
+cc = "1.0"
 handlebars = "0.29"
 serde = "1.0"
 serde_derive = "1.0"

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,4 @@
-extern crate gcc;
+extern crate cc;
 extern crate handlebars as hbs;
 #[macro_use]
 extern crate serde_derive;
@@ -23,7 +23,7 @@ fn main() {
     }
 
     // Build the final library
-    let mut cfg = gcc::Build::new();
+    let mut cfg = cc::Build::new();
 
     let helpers_path = Path::new("src").join("helpers.c");
     cfg.file(&out_path)


### PR DESCRIPTION
Compiling 'interfaces-rs' shows warnings about the 'gcc' crate being deprecated in favor of the 'cc' crate. This pull request makes the fairly trivial changes necessary to switch to that crate.