### PR TITLE
Use 'c_int' ConstantType for all MUSL builds

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -5,14 +5,14 @@ use std::mem;
 use std::os::raw::c_char;
 use std::ptr;
 
-#[cfg(not(target_pointer_width = "32"))]
+#[cfg(all(not(target_pointer_width = "32"), not(target_env = "musl")))]
 pub type ConstantType = u64;
- 
-#[cfg(all(target_pointer_width = "32", target_env = "musl"))]
-pub type ConstantType = i32;
  
 #[cfg(all(target_pointer_width = "32", not(target_env = "musl")))]
 pub type ConstantType = u32;
+
+#[cfg(target_env = "musl")]
+pub type ConstantType = libc::c_int;
 
 /// The constant as sent by the C side.
 #[repr(C)]


### PR DESCRIPTION
I encountered errors building `interfaces-rs` using MUSL on a x86_64:

```
  error[E0308]: mismatched types                                                                                                          
   --> src/lib.rs:389:45                                                                                                                
    |                                                                                                                                   
389 |         let res = unsafe { ioctl(self.sock, SIOCGIFHWADDR, &mut req) };                                                           
    |                                             ^^^^^^^^^^^^^ expected i32, found u64                                                 
                                                                                                                                        
error[E0308]: mismatched types                                                                                                          
   --> src/lib.rs:476:45                                                                                                                
    |                                                                                                                                   
476 |         let res = unsafe { ioctl(self.sock, SIOCGIFFLAGS, &mut req) };                                                            
    |                                             ^^^^^^^^^^^^ expected i32, found u64                                                  
                                                                                                                                        
error[E0308]: mismatched types                                                                                                          
   --> src/lib.rs:494:45                                                                                                                
    |                                                                                                                                   
494 |         let res = unsafe { ioctl(self.sock, SIOCSIFFLAGS, &mut req) };                                                            
    |                                             ^^^^^^^^^^^^ expected i32, found u64                                                  
                                                                                                                                        
error[E0308]: mismatched types                                                                                                          
   --> src/lib.rs:520:45                                                                                                                
    |                                                                                                                                   
520 |         let res = unsafe { ioctl(self.sock, SIOCGIFMTU, &mut req) };                                                              
    |                                             ^^^^^^^^^^ expected i32, found u64                                                    
```

Instead of adding additional special cases, lets simply use 'libc::c_int' which is the type for the second parameter to the ioctl function when using MUSL as libc.

A similar more generic set of changes could possibly also be done for other platforms (as the wanted type is almost always one of `libc::c_int` or `libc::c_ulong`, where the C definition takes care of the relevant width of the integers), but I was afraid of unintended breakage on platforms that I don't have access to at the moment.