### PR TITLE
Upgrade `nix` and other dependencies mainly to avoid RUSTSEC-2021-0119

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ build       = "build.rs"
 bitflags    = "1.0"
 lazy_static = "1.0"
 libc        = "0.2"
-nix         = "0.19"
+nix         = "0.23.0"
 
 [build-dependencies]
 cc              = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,9 @@ license     = "MIT/Apache-2.0"
 build       = "build.rs"
 
 [dependencies]
-bitflags    = "1.0"
-lazy_static = "1.0"
-libc        = "0.2"
+bitflags    = "1.3.2"
+lazy_static = "1.4.0"
+libc        = "0.2.103"
 nix         = "0.23.0"
 
 [build-dependencies]


### PR DESCRIPTION
cargo-audit warn me that nix 0.19.1 has vulnerability.

https://rustsec.org/advisories/RUSTSEC-2021-0119.html

```
03:20:16 : cargo test
   Compiling interfaces v0.0.7 (/Users/alisue/ghq/github.com/fixpoint/interfaces-rs)
    Finished test [unoptimized + debuginfo] target(s) in 0.63s
     Running unittests (target/debug/deps/interfaces-a6fe5f37f39bd503)

running 7 tests
test ffi::tests::test_make_int16 ... ok
test error::tests::test_error_has_traits ... ok
test tests::test_hardwareaddr_deriving ... ok
test tests::test_hardwareaddr_format ... ok
test constants::tests::test_not_existing ... ok
test constants::tests::test_existing ... ok
test tests::test_interface_is_comparable ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests interfaces

running 4 tests
test src/lib.rs - Interface::get_by_name (line 278) ... ok
test src/lib.rs - HardwareAddr::as_string (line 124) ... ok
test src/lib.rs - HardwareAddr::as_bare_string (line 141) ... ok
test src/lib.rs - HardwareAddr::as_bytes (line 157) ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.96s
```