### PR TITLE
Migrate to Rust 2021, do a clippy pass and update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,9 @@ build       = "build.rs"
 bitflags    = "1.3.2"
 lazy_static = "1.4.0"
 libc        = "0.2.103"
-nix         = "0.23.0"
+nix         = "0.24.0"
 
 [build-dependencies]
 cc         = "1"
-handlebars = "0.29"
+handlebars = "4"
 serde      = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name        = "interfaces"
 description = "A Rust library for interacting with network interfaces"
 version     = "0.0.8"
+edition     = "2021"
 authors     = ["Naoya Hatta <dalance@gmail.com>", "Arvid E Picciani <aep@exys.org>", "Andrew Dunham <andrew@du.nham.ca>"]
 homepage    = "https://github.com/andrew-d/interfaces-rs"
 repository  = "https://github.com/andrew-d/interfaces-rs"
@@ -15,7 +16,6 @@ libc        = "0.2.103"
 nix         = "0.23.0"
 
 [build-dependencies]
-cc              = "1"
-handlebars      = "0.29"
-serde           = "1.0"
-serde_derive    = "1.0"
+cc         = "1"
+handlebars = "0.29"
+serde      = { version = "1.0", features = ["derive"] }

--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,3 @@
-extern crate cc;
-extern crate handlebars as hbs;
-#[macro_use]
-extern crate serde_derive;
-
 use std::convert::From;
 use std::fs::File;
 use std::io::{self, Read};
@@ -10,6 +5,9 @@ use std::path::{Path, PathBuf};
 use std::process::exit;
 
 use std::env;
+
+use handlebars as hbs;
+use serde::{Deserialize, Serialize};
 
 fn main() {
     let in_path = Path::new("src").join("constants.c.in");

--- a/build.rs
+++ b/build.rs
@@ -80,11 +80,11 @@ fn make_data() -> Context {
     let anames: &[&str] = &["sizeof(struct ifreq)"];
 
     let names = names
-        .into_iter()
+        .iter()
         .map(|x| String::from(*x))
         .collect::<Vec<String>>();
     let anames = anames
-        .into_iter()
+        .iter()
         .map(|x| String::from(*x))
         .collect::<Vec<String>>();
 
@@ -102,25 +102,25 @@ struct Context {
 
 #[derive(Debug)]
 enum Error {
-    IoError(io::Error),
-    TemplateError(hbs::TemplateError),
-    RenderError(hbs::RenderError),
+    Io(io::Error),
+    Template(hbs::TemplateError),
+    Render(hbs::RenderError),
 }
 
 impl From<io::Error> for Error {
     fn from(e: io::Error) -> Error {
-        Error::IoError(e)
+        Error::Io(e)
     }
 }
 
 impl From<hbs::TemplateError> for Error {
     fn from(e: hbs::TemplateError) -> Error {
-        Error::TemplateError(e)
+        Error::Template(e)
     }
 }
 
 impl From<hbs::RenderError> for Error {
     fn from(e: hbs::RenderError) -> Error {
-        Error::RenderError(e)
+        Error::Render(e)
     }
 }

--- a/build.rs
+++ b/build.rs
@@ -42,17 +42,15 @@ fn main() {
 
 fn template_file(in_path: &PathBuf, out_path: &PathBuf) -> Result<(), Error> {
     // Open and read the file.
-    let mut f = File::open(in_path)?;
+    let mut in_file = File::open(in_path)?;
     let mut s = String::new();
-    f.read_to_string(&mut s)?;
+    in_file.read_to_string(&mut s)?;
 
-    let mut handlebars = hbs::Handlebars::new();
-    handlebars.register_template_string("template", s)?;
-
-    let mut f = File::create(out_path)?;
+    let handlebars = hbs::Handlebars::new();
+    let mut out_file = File::create(out_path)?;
 
     let data = make_data();
-    handlebars.renderw("template", &data, &mut f)?;
+    handlebars.render_template_to_write(&s, &data, &mut out_file)?;
 
     Ok(())
 }

--- a/examples/ifconfig-simple.rs
+++ b/examples/ifconfig-simple.rs
@@ -1,6 +1,5 @@
 extern crate interfaces;
 
-use std::iter;
 use std::net;
 
 use interfaces::{
@@ -9,7 +8,7 @@ use interfaces::{
 };
 
 // Flag mappings that ifconfig uses, in order.
-const NAME_MAPPINGS: &'static [(flags::InterfaceFlags, &'static str)] = &[
+const NAME_MAPPINGS: &[(flags::InterfaceFlags, &str)] = &[
     (InterfaceFlags::IFF_UP, "UP"),
     (InterfaceFlags::IFF_LOOPBACK, "LOOPBACK"),
     (InterfaceFlags::IFF_BROADCAST, "BROADCAST"),
@@ -25,13 +24,10 @@ fn main() {
 
     // Find the maximum alignment for our interface names.
     let max_align = ifs.iter().map(|i| i.name.len() + 2).max().unwrap();
-
-    let full_align = iter::repeat(' ').take(max_align).collect::<String>();
+    let full_align = " ".repeat(max_align);
 
     for i in ifs.iter() {
-        let name_align = iter::repeat(' ')
-            .take(max_align - i.name.len() - 2)
-            .collect::<String>();
+        let name_align = " ".repeat(max_align - i.name.len() - 2);
 
         // Build the first line by printing the interface flags.
         let first_line = {
@@ -55,10 +51,8 @@ fn main() {
 
         if i.flags.contains(InterfaceFlags::IFF_LOOPBACK) {
             println!("{}loop (Local Loopback)", full_align);
-        } else {
-            if let Ok(addr) = i.hardware_addr() {
-                println!("{}ether {}", full_align, addr);
-            }
+        } else if let Ok(addr) = i.hardware_addr() {
+            println!("{}ether {}", full_align, addr);
         }
 
         for addr in i.addresses.iter() {
@@ -80,7 +74,7 @@ fn main() {
 
 fn format_addr(addr: &net::SocketAddr) -> String {
     match addr {
-        &net::SocketAddr::V4(ref a) => format!("{}", a.ip()),
-        &net::SocketAddr::V6(ref a) => format!("{}", a.ip()),
+        net::SocketAddr::V4(a) => format!("{}", a.ip()),
+        net::SocketAddr::V6(a) => format!("{}", a.ip()),
     }
 }

--- a/examples/ifconfig-simple.rs
+++ b/examples/ifconfig-simple.rs
@@ -1,5 +1,3 @@
-extern crate interfaces;
-
 use std::net;
 
 use interfaces::{

--- a/examples/ifupdown.rs
+++ b/examples/ifupdown.rs
@@ -1,5 +1,3 @@
-extern crate interfaces;
-
 use std::env;
 use std::process::exit;
 

--- a/src/constants.c.in
+++ b/src/constants.c.in
@@ -14,14 +14,18 @@ constant_t* rust_get_constants() {
     static constant_t constants[] = {
         // Testable constants
         {{~ #each test_constants as |c|}}
+
 #ifdef {{c}}
             { "{{c}}", {{c}} },
 #endif
+
         {{~ /each}}
 
         // "Always" constants
         {{~ #each always_constants as |c|}}
+
             { "{{c}}", {{c}} },
+            
         {{/each}}
 
         // End of list sentinel

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -74,7 +74,7 @@ lazy_static! {
         }
 
         // Convert from the C-provided type into a hashmap.
-        let ret = cvals
+        cvals
             .into_iter()
             .map(|v| {
                 // HashMap has a from_iter method that accepts (key, value) tuples.
@@ -83,14 +83,13 @@ lazy_static! {
                      v.value as ConstantType
                  )
             })
-            .collect::<HashMap<_, _>>();
-        ret
+            .collect::<HashMap<_, _>>()
     };
 }
 
 pub fn get_constant<S: AsRef<str>>(name: S) -> Option<ConstantType> {
     // Since `u64` is `Copy`, we can dereference the constant directly
-    CONSTANTS.get(name.as_ref()).map(|v| *v)
+    CONSTANTS.get(name.as_ref()).copied()
 }
 
 #[cfg(test)]

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -5,6 +5,8 @@ use std::mem;
 use std::os::raw::c_char;
 use std::ptr;
 
+use lazy_static::lazy_static;
+
 #[cfg(any(
     target_os = "fuchsia",
     target_os = "haiku",

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,8 +2,6 @@ use std::convert::From;
 use std::error::Error;
 use std::fmt;
 
-use nix;
-
 /// InterfacesError is the error type that is returned by all functions in this crate.  See the
 /// documentation on the individual variants for more information.
 #[derive(Debug)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,7 +21,7 @@ impl InterfacesError {
     /// Create a new instance of `InterfacesError` with the error set to the current value of the
     /// libc `errno` variable.
     pub fn last_os_error() -> InterfacesError {
-        return InterfacesError::Errno(nix::errno::Errno::last());
+        InterfacesError::Errno(nix::errno::Errno::last())
     }
 }
 

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -1,3 +1,5 @@
+use bitflags::bitflags;
+
 bitflags! {
     /// Represents a set of flags that describe the state of an interface.  This corresponds to the
     /// flags that are returned from the `SIOCGIFFLAGS` syscall

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,13 +4,6 @@
 //!
 //! TODO: add more documentation on how to use.
 
-#[macro_use]
-extern crate bitflags;
-#[macro_use]
-extern crate lazy_static;
-extern crate libc;
-extern crate nix;
-
 use std::collections::HashMap;
 use std::ffi::CStr;
 use std::fmt;


### PR DESCRIPTION
Hey! So I'm doing a dependency pass on some code at the moment and I noticed an ancient version of `regex` (together with some more recent versions) being compiled in. Looking at this in detail showed the `regex` dependency comes through the 4 year old version of `handlebars` used in the build script here. While #18 notes something similar, they were satisfied with it not being a runtime dependency, while I am trying to get rid of the additional compile time.

Hence, I have updated the `handlebars` dependency (and also minorly bumped `nix`) and in the process silenced some clippy lints and migrated to the 2021 edition (there wasn't really anything to do here, besides specifying the edition in `Cargo.toml`).

Do you think we could get a release with the updated dependency tree? 