### PR TITLE
Upgrade handlebars and other dependencies mainly to avoid RUSTSEC-2022-0013

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,13 +9,13 @@ license     = "MIT/Apache-2.0"
 build       = "build.rs"
 
 [dependencies]
-bitflags    = "1.3.2"
+bitflags    = "2.2"
 lazy_static = "1.4.0"
 libc        = "0.2.103"
-nix         = "0.23.0"
+nix         = "0.26.0"
 
 [build-dependencies]
 cc              = "1"
-handlebars      = "0.29"
+handlebars      = "3.5.5"
 serde           = "1.0"
 serde_derive    = "1.0"

--- a/build.rs
+++ b/build.rs
@@ -54,7 +54,7 @@ fn template_file(in_path: &PathBuf, out_path: &PathBuf) -> Result<(), Error> {
     let mut f = File::create(out_path)?;
 
     let data = make_data();
-    handlebars.renderw("template", &data, &mut f)?;
+    handlebars.render_to_write("template", &data, &mut f)?;
 
     Ok(())
 }

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -1,6 +1,7 @@
 bitflags! {
     /// Represents a set of flags that describe the state of an interface.  This corresponds to the
     /// flags that are returned from the `SIOCGIFFLAGS` syscall
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     pub struct InterfaceFlags: u32 {
         /// Interface is up.
         const IFF_UP = 0x1;


### PR DESCRIPTION
cargo-audit warn me that regex 0.2.11 (imported by handlebars@0.29) has vulnerability.

- https://rustsec.org/advisories/RUSTSEC-2022-0013

```
Crate:     regex
Version:   0.2.11
Title:     Regexes with large repetitions on empty sub-expressions take a very long time to parse
Date:      2022-03-08
ID:        RUSTSEC-2022-0013
URL:       https://rustsec.org/advisories/RUSTSEC-2022-0013
Solution:  Upgrade to >=1.5.5
Dependency tree:
regex 0.2.11
└── handlebars 0.29.1
    └── interfaces 0.0.8
```